### PR TITLE
Work towards a running CP

### DIFF
--- a/api/v1beta1/microk8scontrolplane_types.go
+++ b/api/v1beta1/microk8scontrolplane_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/api/v1beta1"
+	"github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/apis/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"

--- a/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
+++ b/config/crd/bases/controlplane.cluster.x-k8s.io_microk8scontrolplanes.yaml
@@ -20,12 +20,12 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - description: MicroK8sControlPlane API Server is ready to receive requests
+    - description: TalosControlPlane API Server is ready to receive requests
       jsonPath: .status.ready
       name: Ready
       type: boolean
     - description: This denotes whether or not the control plane has the uploaded
-        microk8s-config configmap
+        talos-config configmap
       jsonPath: .status.initialized
       name: Initialized
       type: boolean
@@ -176,12 +176,16 @@ spec:
                               convert recognized schemas to the latest internal value,
                               and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
+                          connectionToken:
+                            type: string
                           kind:
                             description: 'Kind is a string value representing the
                               REST resource this object represents. Servers may infer
                               this from the endpoint the client submits requests to.
                               Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
+                        required:
+                        - connectionToken
                         type: object
                     type: object
                   init:
@@ -293,12 +297,16 @@ spec:
                               convert recognized schemas to the latest internal value,
                               and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
                             type: string
+                          connectionToken:
+                            type: string
                           kind:
                             description: 'Kind is a string value representing the
                               REST resource this object represents. Servers may infer
                               this from the endpoint the client submits requests to.
                               Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                             type: string
+                        required:
+                        - connectionToken
                         type: object
                     type: object
                 required:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,8 +6,6 @@ resources:
 #+kubebuilder:scaffold:crdkustomizeresource
 commonLabels:
   cluster.x-k8s.io/provider: microk8s
-  cluster.x-k8s.io/v1alpha3: v1beta1
-  cluster.x-k8s.io/v1alpha4: v1beta1
   cluster.x-k8s.io/v1beta1: v1beta1
 
 patchesStrategicMerge:

--- a/controllers/configs.go
+++ b/controllers/configs.go
@@ -3,10 +3,13 @@ package controllers
 import (
 	"context"
 	"net"
+	"strings"
 	"time"
 
-	bootstrapv1beta1 "github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/api/v1beta1"
+	bootstrapv1beta1 "github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/apis/v1beta1"
+
 	clusterv1beta1 "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
+
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +21,30 @@ import (
 	"k8s.io/utils/pointer"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	dummyConfig string = `
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUREekNDQWZlZ0F3SUJBZ0lVQnNwdzRSbXNNTUlFRHBJU1BHcjlMSHUyZlgwd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0Z6RVZNQk1HQTFVRUF3d01NVEF1TVRVeUxqRTRNeTR4TUI0WERUSXlNRFl4TnpFeU1qVXhPVm9YRFRNeQpNRFl4TkRFeU1qVXhPVm93RnpFVk1CTUdBMVVFQXd3TU1UQXVNVFV5TGpFNE15NHhNSUlCSWpBTkJna3Foa2lHCjl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUFxY1lEd3NCbUpMSm1rZXg5bTQ0eCtJMlQ3Q3lvSlFvQ1p4UUEKSGtPRDNiNjhzME9IVWt4dW1YWmUwWHZGOVRQVy9yR0tlb1ZBRUpKMG53eHpEY3M4ZlZ6TXA0UmZ1S1BoL2NmVApOZVJNa2J3WFgxYVgxTXBrTzUxRzdEWm05bG90bVo4Q1V6TnZDaTlwUzBhTzM1WU9EcGh4UGtxT2tYamRuQm5BClhIWFdWUFJqdzZ6UGhYY3dXQVpVMDVlbDhpSFU4Wk1vMlk5eVhaNnhpcWk2Z01lc3p0SlgxQzFVUll6cXRvUU8KeVNrOHNsbUVxMXNRUUQxNjFTTFZsZ3VENy9WSG5LSGZ5bEJyZlFiaUcvcGkxZm5BdnhXYm1ZOG1vc2hpWm4xcwpDazMzbzc2NE93QXk4UFNDVElyNXJnOWJ5TUl2c0h3NkRVZ09qekljSlU2a3V1Z0xRd0lEQVFBQm8xTXdVVEFkCkJnTlZIUTRFRmdRVVBEQUhLYjlGVDdNOEJCREk3WUhtVDNGdmdPWXdId1lEVlIwakJCZ3dGb0FVUERBSEtiOUYKVDdNOEJCREk3WUhtVDNGdmdPWXdEd1lEVlIwVEFRSC9CQVV3QXdFQi96QU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBSHZleWQwc3RGaHFjVERPZ09HMHJaWFcwUjNLRGxwVzc2NkZBRGRwOTZ5UGREeG9xZ2dUQktraDBjZ3Z6CmFub2oxR0JmK0ZFWVFuRjlJb29zbXFZWHlFVTNlU05MU2M1NmVpNTFXeWVDa1BROU9RZnZPejlRU2tDT2lVckgKRXhzVzlQRTZXOTBjSVJ6M0h6RXhHeUtFK1JDZUNqZlpDVmNtTUFXMEVrdVVyeHQvY3JJemhxSlFhNUJOV1hGcwo2cEVTWUFJbGtxY0ROZ3lJbjhhVWMxK2hKdVdRamxXeElRc3FnT09GNG56ZjlLTGNCek1sQ0Q0cFc4ekZWRXg0ClhVWEI1NlhyWGdKMzJJbjBxK045dHlXVkN3STZLdUYxak81blhqU0xDQTRQdkpBcmg3YjFsN2lJOGZxR09yaXQKdGFKTlR5N1pwOTFCclBWN3Nha1A1eFQrbXc9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+    server: https://<HOST>:6443
+  name: microk8s-cluster
+contexts:
+- context:
+    cluster: microk8s-cluster
+    user: admin
+  name: microk8s
+current-context: microk8s
+kind: Config
+preferences: {}
+users:
+- name: admin
+  user:
+    client-certificate-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN4ekNDQWE4Q0ZCNlVJb0ZQSzVTYnBiNWo0ZWNXa3hvYWkzaW5NQTBHQ1NxR1NJYjNEUUVCQ3dVQU1CY3gKRlRBVEJnTlZCQU1NRERFd0xqRTFNaTR4T0RNdU1UQWVGdzB5TWpBMk1UY3hOVEl4TXpkYUZ3MHpPVEV4TURVeApOVEl4TXpkYU1Da3hEakFNQmdOVkJBTU1CV0ZrYldsdU1SY3dGUVlEVlFRS0RBNXplWE4wWlcwNmJXRnpkR1Z5CmN6Q0NBU0l3RFFZSktvWklodmNOQVFFQkJRQURnZ0VQQURDQ0FRb0NnZ0VCQUtqMmZONE8zUkQyWEtPRjJhNlMKUmIxQ3NZckh6eTZ6SFVBWGN6REJKZFYya1hVUWJSRVVaaWtPUkM5c0xnU2NFdFhiOHJpSGxKWG5YWkMzZ3RtUwphNnF4V1MwckFrWTBNREd5SW8xOVlXV2gyZUZvUVZPR1kweFdHeG9kd1BTY0ZoZnhVbVZTbS9ndzlEcFd2MnF3Cm9yV1hLUFlCZU1zeDBrbWdkRnZ0L2hzRXB3ZUt2U3FRYUJ5NGpyYmN2Tk05ZkcrbXJYQ01kY0VDRVRHZGNVTHAKTVB1VTdpcXgyMFkrRWkycWpwTDQwRWxjZVY2MDVzbThrb09mbjhOUFJ0anp5dTYrdFFkb0NRTGJyY2tlZFYyOAp6dmR2b1VJVmlKV25KbmgzaVVLR1F0cUtjMHcrdmVYSXl3blMzL1BMOXUxSmZhb3A0eXZUYjBmNVdQSFRTL244CjI3OENBd0VBQVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQWRrdjB5aS9kZkxXbWIxTU0vMklaYUhXcHpjR1QKb2kyS3lHMFJDOGtHQmxNeHZPYjBSY0d0ck9zdzNqdCtyOFU4ODRkZmV5NjI3cTZGZzdSQUxjWHowNk9aMXRCOQpTL3JGaFdGOHM1QlBJaWd1T2g2RWdMeWVoWitUczNzakZDaWdtZU83QWxVdGV0Q0xvWElNZmkwZG5PMzJJbkdUCndtTWR0aEh3c3pkaE10UGFHNG03YUYycmw1a1RSZlJla3NYd3J1M2ZNalR4MC9jdlU5dTF0MDdJbkVRdW5LaSsKbDBlSlFaVVNYNGx3dkJXb0hvYnZpOXdoMW9oSVJpRFZ1OExYS0xWbUZwQ1BuMG0wTzlxRXRUbnZ3Wi9tSk5DOApOL1VQVTMzVi9DZitEK1c1dC9LdG1GUzErQ0I0WW1DYlNkK3BseFdOaVNaY0orajd2MlRITnVVcHhRPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+    client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb2dJQkFBS0NBUUVBcVBaODNnN2RFUFpjbzRYWnJwSkZ2VUt4aXNmUExyTWRRQmR6TU1FbDFYYVJkUkJ0CkVSUm1LUTVFTDJ3dUJKd1MxZHZ5dUllVWxlZGRrTGVDMlpKcnFyRlpMU3NDUmpRd01iSWlqWDFoWmFIWjRXaEIKVTRaalRGWWJHaDNBOUp3V0YvRlNaVktiK0REME9sYS9hckNpdFpjbzlnRjR5ekhTU2FCMFcrMytHd1NuQjRxOQpLcEJvSExpT3R0eTgwejE4YjZhdGNJeDF3UUlSTVoxeFF1a3crNVR1S3JIYlJqNFNMYXFPa3ZqUVNWeDVYclRtCnlieVNnNStmdzA5RzJQUEs3cjYxQjJnSkF0dXR5UjUxWGJ6TzkyK2hRaFdJbGFjbWVIZUpRb1pDMm9welRENjkKNWNqTENkTGY4OHYyN1VsOXFpbmpLOU52Ui9sWThkTkwrZnpidndJREFRQUJBb0lCQUIzVGpVMWgwRko3T3ZVKwozcU43Zk1ZaExOZ3oxM1lGOW1ibS9OV2hjdjFRdGZLMVdKdUlQMVNHQ1RGWjVuRzMzM2RUSVhERHRrNFVEcWRLClRkWDhpL2NRNFk0Z3BvRWdHMVhhZlZEK3poK3p4NU9MNU9SS3QrSzAzSW5xc0xJOWo0VGdlOHdaSGlGYyt2QUYKZWpycVBYN1MxVTlBQ1VQTllyTE9tVnZWRW1OUVVGaElzV2dhZkVaUndiNUI0UEtmK2toOEZLNngzR1duL0xIbgpCWG5XVU50VENGZjkzZ1dwYkFzc29KcjFCVVMzV1AwcFZaTmhzWWZpWWZoNm0xdnlIYUNNRHgyTXJpakhLZGJJClJOTXViWWFlOHZWQ0x3Q0tlOEloOGxLNWgwc2lZNk1YYlIwT2Mrc3Zaa3JJSkdjWmF3aHZFaU9NSnIxclprZ1AKRFVRK1YrRUNnWUVBM21DU2kzVytXZDNNTXgrdkRCUmtPNWJkdTM3alVKdXptZ1grVVFCY0pZa2hGb08vb1czago3blp1YkpoZ2VZUUhSektHT3NrQm1oV05CVFlLV1IxRnV0WEpwdmp6T1JtSXRYRStBTFVLRml3QUw2U0ZRSDcwCjlpK3U2UFBXS0NXMW5laVRxNnMzU0pGNkFWZTRwUERtRThsYXFTOXovWkUyMU42MEFKQS9yNUVDZ1lFQXdvSnYKWjdRU0VGb3ZOSlFSR0t1SVQ0MUE4U3lxRW92elJKRGRLakxZT0h4WW9kWUh0a2duMDZTaDU1MDVCem5qMXhxcgovVGdpRnQyT1V6eHNLbFJyY2RLWXljY2VySVM0L1Rad1YxK2dKQWJBRU5nK2d6THJ0dzJOcFF6UTJuK0NlbEpSCmc2V1JQcUlqM0xtS1hZZ0s4VWlGaHZwYVRkcVBYTVBhSFd5ZnprOENnWUI3K0F4YUVLYXdSSlNNdjVIL1F2THAKd1Y0VkkxU240RlVNZldEY1dUNEZjdC91UkQ0MVNTU3pFSFRZdDAyNUVHQmFVWkZBL2tPVldZUkhMbXd3WjhBeQp1dkh5MG9BTkNlNExjSGpuUGdYRWZIMFNFajV5eVJQWWxwYUVxVUp2R1M2WlBFbnVmc0dRQkFHbTgvY3NoRnRQCkZvWWpJU0FoY0szSGwrdHpFUGRmOFFLQmdEZFRSSDdaMEQySWVWN2FNdGF5aTY0Yy9uamEvSEVVRDVqVUg2Uk8KSEFSTkVpVE9MUmxqQXJrSFhlbjBaWEV4dlNYRTkyQ3FJOEFmT3NsZ0tXQU03UmJPRVJscm9zVHRaM1RXbERPMgpCbVhZNmE2ZzQzOEw3OUg4YitxZmI1U0dxa1ZDdnQ3VUxERUZpMi9QOHBSU0N0TEFqd0pxbVY4RnFMdDVGY1JDCnpsMnZBb0dBWjZnR1FIcEw2YXpvUkhsZlFkK2prdGo4dFpVNU4xaUtmVEFLMENYMk1CdGJHWUpiOEtNM2NhMGEKVms2MFBHYSs1OWhVTHgzblBSaU5maVBPVXdNS2JFcTBOeFhqbjN5YXRxTnBPcWlQUUlDaEdZQjVmN2IwaGZPUQpaM1orOFZQVHB3OTd1QVBVVUdaUmZPdUhQczFGYzA1TElrNGpxOTRjb0VUK0h2Mm1nNTQ9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==
+`
 )
 
 type kubernetesClient struct {
@@ -42,7 +69,44 @@ func newDialer() *connrotation.Dialer {
 func (r *MicroK8sControlPlaneReconciler) kubeconfigForCluster(ctx context.Context, cluster client.ObjectKey) (*kubernetesClient, error) {
 	kubeconfigSecret := &corev1.Secret{}
 
-	err := r.Client.Get(ctx,
+	// See if the kubeconfig exists. If not create it.
+	secrets := &corev1.SecretList{}
+	err := r.Client.List(ctx, secrets)
+	if err != nil {
+		return nil, err
+	}
+
+	found := false
+	for _, s := range secrets.Items {
+		if s.Name == cluster.Name+"-kubeconfig" {
+			found = true
+		}
+	}
+
+	c := &clusterv1.Cluster{}
+	err = r.Client.Get(ctx, cluster, c)
+	if err != nil {
+		return nil, err
+	}
+	if !found && c.Spec.ControlPlaneEndpoint.IsValid() {
+
+		realDummyConfig := strings.Replace(dummyConfig, "<HOST>", c.Spec.ControlPlaneEndpoint.Host, -1)
+		configsecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: cluster.Namespace,
+				Name:      cluster.Name + "-kubeconfig",
+			},
+			Data: map[string][]byte{
+				"value": []byte(realDummyConfig),
+			},
+		}
+		err = r.Client.Create(ctx, configsecret)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = r.Client.Get(ctx,
 		types.NamespacedName{
 			Namespace: cluster.Namespace,
 			Name:      cluster.Name + "-kubeconfig",

--- a/controllers/healthchecks.go
+++ b/controllers/healthchecks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	clusterv1beta1 "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/controllers/microk8scontrolplane_controller.go
+++ b/controllers/microk8scontrolplane_controller.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	clusterv1beta1 "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"

--- a/controllers/reconcile.go
+++ b/controllers/reconcile.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	clusterv1beta1 "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
+
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -147,8 +148,7 @@ func (r *MicroK8sControlPlaneReconciler) reconcileMachines(ctx context.Context,
 
 		if numMachines == 1 {
 			conditions.MarkFalse(mcp, clusterv1beta1.ResizedCondition, clusterv1beta1.ScalingDownReason, clusterv1.ConditionSeverityError,
-				"Cannot scale down control plane nodes to 0",
-				desiredReplicas, numMachines)
+				"Cannot scale down control plane nodes to 0")
 
 			return res, nil
 		}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	clusterv1beta1 "cluster-api-control-plane-provider-microk8s/api/v1beta1"
+	clusterv1beta1 "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,20 +3,22 @@ module github.com/AlexsJones/cluster-api-control-plane-provider-microk8s
 go 1.17
 
 require (
-	github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s v0.0.0-20220405083620-d2efbd3ad610
+	github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s v0.0.0-20220511083622-b3647739f72d
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.19.0
 	github.com/sirupsen/logrus v1.8.1
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
+	k8s.io/apiserver v0.23.5
 	k8s.io/client-go v0.23.5
 	sigs.k8s.io/controller-runtime v0.11.2
 )
 
+replace github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s => github.com/ktsakalozos/cluster-api-bootstrap-provider-microk8s v0.0.0-20220620194523-668a92209b50
+
 require (
 	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/gobuffalo/flect v0.2.4 // indirect
-	k8s.io/apiserver v0.23.5 // indirect
 )
 
 require (
@@ -75,7 +77,7 @@ require (
 	k8s.io/component-base v0.23.5 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/cluster-api v1.1.3
 	sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,6 @@ cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohl
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s v0.0.0-20220405083620-d2efbd3ad610 h1:nYR+O71vxAtMIk2YRoOm2+QY7jz3TRz6IkE02CnJGZM=
-github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s v0.0.0-20220405083620-d2efbd3ad610/go.mod h1:GfwL+xjRcD4UW5qbpr4dJZiP+dmV3U0nsGBIMg9OCg0=
 github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
@@ -413,6 +411,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/ktsakalozos/cluster-api-bootstrap-provider-microk8s v0.0.0-20220620194523-668a92209b50 h1:y86hcQHo6kQ5hr+5o2gOwEpvM2zhNZeAK8YI+5giHdw=
+github.com/ktsakalozos/cluster-api-bootstrap-provider-microk8s v0.0.0-20220620194523-668a92209b50/go.mod h1:Lcl1cI0PELeLc1EGA/FCfZaC/W77dsHmt75iskFTgwI=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/main.go
+++ b/main.go
@@ -24,9 +24,11 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	bootstrapv1beta1 "github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/api/v1beta1"
-	clusterv1beta1 "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
-	mcpcontroller "github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/controllers"
+	"github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/api/v1beta1"
+	"github.com/AlexsJones/cluster-api-control-plane-provider-microk8s/controllers"
+
+	bootstrapv1beta1 "github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/apis/v1beta1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -46,7 +48,7 @@ var (
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
-	utilruntime.Must(clusterv1beta1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
 
 	utilruntime.Must(bootstrapv1beta1.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
@@ -56,8 +58,8 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
-	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
-	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8082", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8083", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -82,7 +84,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	mcp := mcpcontroller.MicroK8sControlPlaneReconciler{
+	mcp := controllers.MicroK8sControlPlaneReconciler{
 		Client:    mgr.GetClient(),
 		APIReader: mgr.GetAPIReader(),
 		Scheme:    mgr.GetScheme(),
@@ -93,7 +95,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&clusterv1beta1.MicroK8sControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
+	if err = (&v1beta1.MicroK8sControlPlane{}).SetupWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "MicroK8sConfigTemplate")
 		os.Exit(1)
 	}

--- a/scripts/local-cluster.sh
+++ b/scripts/local-cluster.sh
@@ -1,6 +1,6 @@
 # cat >> cluster.config << EOF
 # kind: Cluster
-# apiVersion: kind.x-k8s.io/v1alpha4
+# apiVersion: kind.x-k8s.io/v1beta1
 # nodes:
 # - role: control-plane
 #   extraMounts:
@@ -14,7 +14,7 @@ export AWS_NODE_MACHINE_TYPE=t3.medium
 export AWS_SSH_KEY_NAME=default
 kind create cluster
 #kind create cluster --config cluster.config
-clusterctl init --infrastructure aws
+clusterctl init --infrastructure aws --bootstrap "-" --control-plane "-"
 kubectl delete namespace capi-kubeadm-bootstrap-system
 kubectl delete namespace capi-kubeadm-control-plane-system
 make install


### PR DESCRIPTION
This PR allows us to get a single CP running cluster. It depends on https://github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/pull/1 and it needs its go.mod to be updated after the cluster-api-bootstrap-provider-microk8s PR is merged. Here are some notable changes in this PR:

- dummy kubeconfig to match the CA of the https://github.com/AlexsJones/cluster-api-bootstrap-provider-microk8s/pull/1 PR
- ProviderID updated on each node

